### PR TITLE
Python3 support

### DIFF
--- a/bin/chamberconnectlibrary-test.py
+++ b/bin/chamberconnectlibrary-test.py
@@ -39,11 +39,11 @@ if __name__ == '__main__':
     except Exception:
         traceback.print_exc()
 
-        print '\nThe test could not be run try:'
-        print '\nchamberconnectlibrary_test controller interface ipORserialport [baudrate]'
-        print '\tcontroller: "Espec"/"EspecP300", "EspecSCP220", "WatlowF4", or "WatlowF4T"(default)'
-        print '\tinterface: "Serial": Serial connection when "controller" is "Espec".'
-        print '\t           "RTU":Serial connection when "controller" is "WatlowF4T"'
-        print '\t           "TCP":TCP connection'
-        print '\t"hostORserialport": hostname for TCP, or serial port for RTU/Serial'
-        print '\t"baudrate": The baudrate for RTU/Serial, optional(default=9600)'
+        print('\nThe test could not be run try:')
+        print('\nchamberconnectlibrary_test controller interface ipORserialport [baudrate]')
+        print('\tcontroller: "Espec"/"EspecP300", "EspecSCP220", "WatlowF4", or "WatlowF4T"(default)')
+        print('\tinterface: "Serial": Serial connection when "controller" is "Espec".')
+        print('\t           "RTU":Serial connection when "controller" is "WatlowF4T"')
+        print('\t           "TCP":TCP connection')
+        print('\t"hostORserialport": hostname for TCP, or serial port for RTU/Serial')
+        print('\t"baudrate": The baudrate for RTU/Serial, optional(default=9600)')

--- a/bin/example.py
+++ b/bin/example.py
@@ -32,7 +32,7 @@ CONTROLLER = Espec(
 #     baudrate=38400,
 #     loop_names=LOOP_NAMES
 # )
-print CONTROLLER.process_controller()
+print(CONTROLLER.process_controller())
 
 # print '\ncascade loops:'
 # for i in range(CONTROLLER.cascades):
@@ -58,7 +58,7 @@ print CONTROLLER.process_controller()
 #     print CONTROLLER.get_event(i+1)
 
 for _ in range(100):
-    print '\nsample'
+    print('\nsample')
     stm = time.time()
     lookup = {'cascade':[], 'loop':[]}
     lookup['loop'].append({'name':'Temperature', 'id': 1, 'number': 1})
@@ -66,5 +66,5 @@ for _ in range(100):
     params = {'get_loops':True, 'get_status':True, 'get_alarms':True, 'get_program_status':True, 'get_program_list':True, 'get_refrig':True}
     params['get_events'] = [{'N':i+1, 'name':'TS#%d'%(i+1)} for i in range(8)]
     smpl = CONTROLLER.sample(lookup, **params)
-    print("--- %s seconds ---" % (time.time() - stm))
+    print(("--- %s seconds ---" % (time.time() - stm)))
     print(smpl)

--- a/chamberconnectlibrary/controllerinterface.py
+++ b/chamberconnectlibrary/controllerinterface.py
@@ -1042,10 +1042,11 @@ class ControllerInterface(metaclass=ABCMeta):
                 items = ['setpoint', 'processvalue', 'enable', 'mode', 'power', 'units', 'range']
                 if tmap['type'] == 'cascade':
                     items += ['enable_cascade', 'deviation']
-                lkps = [lkp for lkp in lookup[tmap['type']] if lkp['number'] == tmap['num']]
-                lpdata = lkps[0].copy() if lookup else {}
-                lpdata.update(self.get_loop(tmap['num'], tmap['type'], items, exclusive=False))
-                ret['loops'].append(lpdata)
+                if lookup:
+                    lkps = [lkp for lkp in lookup[tmap['type']] if lkp['number'] == tmap['num']]
+                    lpdata = lkps[0].copy() if lookup else {}
+                    lpdata.update(self.get_loop(tmap['num'], tmap['type'], items, exclusive=False))
+                    ret['loops'].append(lpdata)
         if kwargs.get('get_status', True) or kwargs.get('get_program_status', False):
             ret['status'] = self.get_status(exclusive=False)
         if kwargs.get('get_alarms', False):

--- a/chamberconnectlibrary/controllerinterface.py
+++ b/chamberconnectlibrary/controllerinterface.py
@@ -40,9 +40,8 @@ def exclusive(func):
             return func(self, *args, **kwargs)
     return wrapper
 
-class ControllerInterface:
+class ControllerInterface(metaclass=ABCMeta):
     '''Abstract class for a controller implimentation of the chamberconnectlibrary'''
-    __metaclass__ = ABCMeta
 
     loop_map = []
     named_loop_map = {}
@@ -180,7 +179,7 @@ class ControllerInterface:
             }
         }
 
-        if isinstance(identifier, basestring):
+        if isinstance(identifier, str):
             my_loop_map = self.loop_map[self.named_loop_map[identifier]]
             loop_number = my_loop_map['num']
             loop_type = my_loop_map['type']
@@ -197,7 +196,7 @@ class ControllerInterface:
             )
 
         if param_list is None:
-            param_list = loop_functions[loop_type].keys()
+            param_list = list(loop_functions[loop_type].keys())
             excludes = ['setPoint', 'setValue', 'processValue']
             param_list = [x for x in param_list if x not in excludes]
         elif len(param_list) >= 1 and \
@@ -260,11 +259,11 @@ class ControllerInterface:
         }
         if param_list is None:
             param_list = kwargs
-        if isinstance(identifier, basestring):
+        if isinstance(identifier, str):
             my_loop_map = self.loop_map[self.named_loop_map[identifier]]
             loop_number = my_loop_map['num']
             loop_type = my_loop_map['type']
-        elif isinstance(identifier, (int, long)):
+        elif isinstance(identifier, int):
             loop_number = identifier
         else:
             raise ValueError(
@@ -280,7 +279,7 @@ class ControllerInterface:
                 N=loop_number,
                 value=param_list.pop('mode')
             )
-        for key, val in param_list.items():
+        for key, val in list(param_list.items()):
             try:
                 loop_functions[loop_type][key](
                     exclusive=False,
@@ -1135,311 +1134,311 @@ class ControllerInterface:
             '''
             Format an Exception for printing
             '''
-            print '\n'.join(['\t' + l for l in trce.split('\n')])
+            print('\n'.join(['\t' + l for l in trce.split('\n')]))
 
-        print 'process_controller():'
+        print('process_controller():')
         try:
-            print '\t%r' % self.process_controller()
+            print('\t%r' % self.process_controller())
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'get_datetime:'
+        print('get_datetime:')
         try:
-            print '\t%r' % self.get_datetime()
+            print('\t%r' % self.get_datetime())
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'set_datetime:'
+        print('set_datetime:')
         try:
             self.set_datetime(self.get_datetime())
-            print '\tok'
+            print('\tok')
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'get_operation:'
+        print('get_operation:')
         try:
-            print '\t%r' % self.get_operation()
+            print('\t%r' % self.get_operation())
         except Exception:
             print_exception(traceback.format_exc())
 
         for lpi in range(loops):
             i = lpi + 1
-            print 'get_loop_sp(%d):' % i
+            print('get_loop_sp(%d):' % i)
             try:
-                print '\t%r' % self.get_loop_sp(i)
+                print('\t%r' % self.get_loop_sp(i))
             except Exception:
                 print_exception(traceback.format_exc())
-            print 'set_loop_sp(%d):' %i
+            print('set_loop_sp(%d):' %i)
             try:
                 self.set_loop_sp(i, self.get_loop_sp(i)['constant'])
-                print '\tok'
+                print('\tok')
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_loop_pv(%d):' % i
+            print('get_loop_pv(%d):' % i)
             try:
-                print '\t%r' % self.get_loop_pv(i)
+                print('\t%r' % self.get_loop_pv(i))
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_loop_range(%d):' % i
+            print('get_loop_range(%d):' % i)
             try:
-                print '\t%r' % self.get_loop_range(i)
+                print('\t%r' % self.get_loop_range(i))
             except Exception:
                 print_exception(traceback.format_exc())
-            print 'set_loop_range(%d):' %i
+            print('set_loop_range(%d):' %i)
             try:
                 self.set_loop_range(i, self.get_loop_range(i))
-                print '\tok'
+                print('\tok')
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_loop_en(%d):' % i
+            print('get_loop_en(%d):' % i)
             try:
-                print '\t%r' % self.get_loop_en(i)
+                print('\t%r' % self.get_loop_en(i))
             except Exception:
                 print_exception(traceback.format_exc())
-            print 'set_loop_en(%d):' %i
+            print('set_loop_en(%d):' %i)
             try:
                 self.set_loop_en(i, self.get_loop_en(i)['constant'])
-                print '\tok'
+                print('\tok')
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_loop_units(%d):' % i
+            print('get_loop_units(%d):' % i)
             try:
-                print '\t%r' % self.get_loop_units(i)
+                print('\t%r' % self.get_loop_units(i))
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_loop_mode(%d):' % i
+            print('get_loop_mode(%d):' % i)
             try:
-                print '\t%r' % self.get_loop_mode(i)
+                print('\t%r' % self.get_loop_mode(i))
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_loop_power(%d):' % i
+            print('get_loop_power(%d):' % i)
             try:
-                print '\t%r' % self.get_loop_power(i)
+                print('\t%r' % self.get_loop_power(i))
             except Exception:
                 print_exception(traceback.format_exc())
 
         for csi in range(cascades):
             i = csi + 1
-            print 'get_cascade_sp[%d]:' % i
+            print('get_cascade_sp[%d]:' % i)
             try:
-                print '\t%r' % self.get_cascade_sp(i)
+                print('\t%r' % self.get_cascade_sp(i))
             except Exception:
                 print_exception(traceback.format_exc())
-            print 'set_cascade_sp(%d):' %i
+            print('set_cascade_sp(%d):' %i)
             try:
                 self.set_cascade_sp(i, self.get_cascade_sp(i)['constant'])
-                print '\tok'
+                print('\tok')
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_cascade_pv(%d):' % i
+            print('get_cascade_pv(%d):' % i)
             try:
-                print '\t%r' % self.get_cascade_pv(i)
+                print('\t%r' % self.get_cascade_pv(i))
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_cascade_range(%d):' % i
+            print('get_cascade_range(%d):' % i)
             try:
-                print '\t%r' % self.get_cascade_range(i)
+                print('\t%r' % self.get_cascade_range(i))
             except Exception:
                 print_exception(traceback.format_exc())
-            print 'set_cascade_range[%d]:' %i
+            print('set_cascade_range[%d]:' %i)
             try:
                 self.set_cascade_range(i, self.get_cascade_range(i))
-                print '\tok'
+                print('\tok')
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_cascade_en[%d]:' % i
+            print('get_cascade_en[%d]:' % i)
             try:
-                print '\t%r' % self.get_cascade_en(i)
+                print('\t%r' % self.get_cascade_en(i))
             except Exception:
                 print_exception(traceback.format_exc())
-            print 'set_cascade_en(%d):' %i
+            print('set_cascade_en(%d):' %i)
             try:
                 self.set_cascade_en(i, self.get_cascade_en(i)['constant'])
-                print '\tok'
+                print('\tok')
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_cascade_units(%d):' % i
+            print('get_cascade_units(%d):' % i)
             try:
-                print '\t%r' % self.get_cascade_units(i)
+                print('\t%r' % self.get_cascade_units(i))
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_cascade_mode(%d):' % i
+            print('get_cascade_mode(%d):' % i)
             try:
-                print '\t%r' % self.get_cascade_mode(i)
+                print('\t%r' % self.get_cascade_mode(i))
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_cascade_ctl(%d):' % i
+            print('get_cascade_ctl(%d):' % i)
             try:
-                print '\t%r' % self.get_cascade_ctl(i)
+                print('\t%r' % self.get_cascade_ctl(i))
             except Exception:
                 print_exception(traceback.format_exc())
-            print 'set_cascade_ctl(%d):' %i
+            print('set_cascade_ctl(%d):' %i)
             try:
                 self.set_cascade_ctl(i, self.get_cascade_ctl(i))
-                print '\tok'
+                print('\tok')
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_cascade_deviation(%d):' % i
+            print('get_cascade_deviation(%d):' % i)
             try:
-                print '\t%r' % self.get_cascade_deviation(i)
+                print('\t%r' % self.get_cascade_deviation(i))
             except Exception:
                 print_exception(traceback.format_exc())
-            print 'set_cascade_deviation(%d):' %i
+            print('set_cascade_deviation(%d):' %i)
             try:
                 self.set_cascade_deviation(i, self.get_cascade_deviation(i))
-                print '\tok'
+                print('\tok')
             except Exception:
                 print_exception(traceback.format_exc())
 
         for i in range(1, 13):
-            print 'get_event(%d):' % i
+            print('get_event(%d):' % i)
             try:
-                print '\t%r' % self.get_event(i)
+                print('\t%r' % self.get_event(i))
             except Exception:
                 print_exception(traceback.format_exc())
-            print 'set_event(%d):' %i
+            print('set_event(%d):' %i)
             try:
                 self.set_event(i, self.get_event(i)['current'])
-                print '\tok'
+                print('\tok')
             except Exception:
                 print_exception(traceback.format_exc())
 
-        print 'get_status:'
+        print('get_status:')
         try:
-            print '\t%r' % self.get_status()
+            print('\t%r' % self.get_status())
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'get_alarm_status:'
+        print('get_alarm_status:')
         try:
-            print '\t%r' % self.get_alarm_status()
+            print('\t%r' % self.get_alarm_status())
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'get_prgm_cur:'
+        print('get_prgm_cur:')
         try:
-            print '\t%r' % self.get_prgm_cur()
+            print('\t%r' % self.get_prgm_cur())
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'get_prgm_cstep:'
+        print('get_prgm_cstep:')
         try:
-            print '\t%r' % self.get_prgm_cstep()
+            print('\t%r' % self.get_prgm_cstep())
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'get_prgm_cstime:'
+        print('get_prgm_cstime:')
         try:
-            print '\t%r' % self.get_prgm_cstime()
+            print('\t%r' % self.get_prgm_cstime())
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'get_prgm_time:'
+        print('get_prgm_time:')
         try:
-            print '\t%r' % self.get_prgm_time()
+            print('\t%r' % self.get_prgm_time())
         except Exception:
             print_exception(traceback.format_exc())
 
         for i in range(1, 6): #do 5 programs only
-            print 'get_prgm_name(%d):' % i
+            print('get_prgm_name(%d):' % i)
             try:
-                print '\t%r' % self.get_prgm_name(i)
+                print('\t%r' % self.get_prgm_name(i))
             except Exception:
                 print_exception(traceback.format_exc())
 
-            print 'get_prgm_steps(%d):' % i
+            print('get_prgm_steps(%d):' % i)
             try:
-                print '\t%r' % self.get_prgm_steps(i)
+                print('\t%r' % self.get_prgm_steps(i))
             except Exception:
                 print_exception(traceback.format_exc())
 
-        print 'get_prgms:'
+        print('get_prgms:')
         try:
-            print '\t%r' % self.get_prgms()
+            print('\t%r' % self.get_prgms())
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'get_prgm(1):'
+        print('get_prgm(1):')
         try:
-            print '\t%r' % self.get_prgm(1)
+            print('\t%r' % self.get_prgm(1))
         except Exception:
             print_exception(traceback.format_exc())
-        print 'set_prgm(1):'
+        print('set_prgm(1):')
         try:
             self.set_prgm(2, self.get_prgm(1))
-            print '\tok'
+            print('\tok')
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'get_network_settings:'
+        print('get_network_settings:')
         try:
-            print '\t%r' % self.get_network_settings()
+            print('\t%r' % self.get_network_settings())
         except Exception:
             print_exception(traceback.format_exc())
-        print 'set_network_settings:'
+        print('set_network_settings:')
         try:
             self.set_network_settings(self.get_network_settings())
-            print '\tok'
+            print('\tok')
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'call const_start():'
+        print('call const_start():')
         try:
             self.const_start()
             time.sleep(5)
-            print '\tok'
+            print('\tok')
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'call stop():'
+        print('call stop():')
         try:
             self.stop()
             time.sleep(5)
-            print '\tok'
+            print('\tok')
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'call prgm_start(1,1):'
+        print('call prgm_start(1,1):')
         try:
             self.prgm_start(1, 1)
             time.sleep(5)
-            print '\tok'
+            print('\tok')
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'call prgm_pause():'
+        print('call prgm_pause():')
         try:
             self.prgm_pause()
             time.sleep(5)
-            print '\tok'
+            print('\tok')
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'call prgm_resume():'
+        print('call prgm_resume():')
         try:
             self.prgm_resume()
             time.sleep(5)
-            print '\tok'
+            print('\tok')
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'call sample():'
+        print('call sample():')
         try:
-            print '\t%r' % self.sample()
+            print('\t%r' % self.sample())
         except Exception:
             print_exception(traceback.format_exc())
 
-        print 'Testing Complete'
+        print('Testing Complete')

--- a/chamberconnectlibrary/espec.py
+++ b/chamberconnectlibrary/espec.py
@@ -153,11 +153,11 @@ class Espec(ControllerInterface):
         }
         if param_list is None:
             param_list = kwargs
-        if isinstance(identifier, basestring):
+        if isinstance(identifier, str):
             my_loop_map = self.loop_map[self.named_loop_map[identifier]]
             loop_number = my_loop_map['num']
             loop_type = my_loop_map['type']
-        elif isinstance(identifier, (int, long)):
+        elif isinstance(identifier, int):
             loop_number = identifier
         else:
             raise ValueError(
@@ -204,7 +204,7 @@ class Espec(ControllerInterface):
                 params = {param_list.pop('enable_cascade')}
             params.update(param_list.pop('deviation'))
             self.client.write_temp_ptc(**params)
-        for key, val in param_list.items():
+        for key, val in list(param_list.items()):
             params = {'value':val}
             params.update({'exclusive':False, 'N':loop_number})
             try:
@@ -298,9 +298,9 @@ class Espec(ControllerInterface):
     @exclusive
     def get_loop_units(self, N):
         if self.lpd[N] == self.temp:
-            return u'\xb0C'
+            return '\xb0C'
         elif self.lpd[N] == self.humi:
-            return u'%RH'
+            return '%RH'
         else:
             raise ValueError(self.lp_exmsg)
 

--- a/chamberconnectlibrary/modbus.py
+++ b/chamberconnectlibrary/modbus.py
@@ -401,7 +401,7 @@ class ModbusRTU(Modbus):
         crc = 0xFFFF
         for i in data:
             crc = crc ^ ord(i)
-            for _ in xrange(8):
+            for _ in range(8):
                 tmp = crc & 1
                 crc = crc >> 1
                 if tmp:
@@ -499,4 +499,4 @@ if __name__ == '__main__':
     tst = ModbusRTU(1, 3, baud=38400, low_word_first=True)
     tmp = tst.read_items(pkt)
     for i in tmp:
-        print i # pylint: disable=E1601
+        print(i) # pylint: disable=E1601

--- a/chamberconnectlibrary/modbus.py
+++ b/chamberconnectlibrary/modbus.py
@@ -335,19 +335,19 @@ class Modbus(object):
 
     def _decode_packet(self, packet, spacket):
         '''Decode the modbus request packet.'''
-        fcode = struct.unpack(">B", packet[1])[0]
-        addr = struct.unpack(">B", packet[0])[0]
+        fcode = struct.unpack_from(">B", packet, 1)[0]
+        addr = struct.unpack_from(">B", packet, 0)[0]
         if self.address != addr:
             shex = ":".join("{:02x}".format(ord(c) for c in spacket))
             rhex = ":".join("{:02x}".format(ord(c) for c in packet))
             raise ModbusError("Address error; Sent=%s, Recieved=%s" % (shex, rhex))
         if fcode > 127:
-            ecode = struct.unpack(">B", packet[2])[0]
+            ecode = struct.unpack_from(">B", packet, 2)[0]
             ttp = (ecode, self.error_messages.get(ecode, 'Unknown error code'))
             raise ModbusError('Modbus Error: Exception code = %d(%s)' % ttp)
 
         if fcode in [3, 4]: #Read input/holding register(s)
-            cnt = struct.unpack(">B", packet[2])[0]/2
+            cnt = struct.unpack_from(">B", packet, 2)[0]/2
             return struct.unpack(">%dH" % cnt, packet[3:])
         elif fcode == 6:
             pass #nothing is required

--- a/chamberconnectlibrary/p300.py
+++ b/chamberconnectlibrary/p300.py
@@ -6,7 +6,7 @@ A direct implimentation of the P300's communication interface.
 '''
 #pylint: disable=W0703
 import re
-from especinteract import EspecSerial, EspecTCP
+from .especinteract import EspecSerial, EspecTCP
 
 def tryfloat(val, default):
     '''
@@ -878,7 +878,7 @@ class P300(object):
         '''
         Read the configured IP address of the controller
         '''
-        return dict(zip(['address', 'mask', 'gateway'], self.ctlr.interact('IPSET?').split(',')))
+        return dict(list(zip(['address', 'mask', 'gateway'], self.ctlr.interact('IPSET?').split(','))))
 
     #--- write methods --- write methods --- write methods --- write methods --- write methods ---
     def write_date(self, year, month, day, dow):

--- a/chamberconnectlibrary/p300debug.py
+++ b/chamberconnectlibrary/p300debug.py
@@ -53,4 +53,4 @@ if __name__ == '__main__':
     tst = P300Debug(port=11, baud=38400)
     tmp = tst.read_items(pkt)
     for i in tmp:
-        print i # pylint: disable=E1601
+        print(i) # pylint: disable=E1601

--- a/chamberconnectlibrary/scp220.py
+++ b/chamberconnectlibrary/scp220.py
@@ -4,7 +4,7 @@ A direct implimentation of the SCP220's communication interface.
 :copyright: (C) Espec North America, INC.
 :license: MIT, see LICENSE for more details.
 '''
-from p300 import P300
+from .p300 import P300
 
 class SCP220(P300):
     '''

--- a/chamberconnectlibrary/scp220debug.py
+++ b/chamberconnectlibrary/scp220debug.py
@@ -194,4 +194,4 @@ if __name__ == '__main__':
     tst = SCP220Debug(port=11)
     tmp = tst.read_items(pkt)
     for i in tmp:
-        print i # pylint: disable=E1601
+        print(i) # pylint: disable=E1601

--- a/chamberconnectlibrary/watlowf4.py
+++ b/chamberconnectlibrary/watlowf4.py
@@ -391,9 +391,9 @@ class WatlowF4(ControllerInterface):
     @exclusive
     def get_loop_units(self, N):
         self.__range_check(N, 1, self.loops + self.cascades)
-        units = ['Temp', u'%RH', u'PSI', u''][self.client.read_holding([608, 618, 628][N-1])[0]]
+        units = ['Temp', '%RH', 'PSI', ''][self.client.read_holding([608, 618, 628][N-1])[0]]
         if units == 'Temp':
-            units = u'\xb0C' if self.client.read_holding(901)[0] else u'\xb0F'
+            units = '\xb0C' if self.client.read_holding(901)[0] else '\xb0F'
         return units
 
     @exclusive

--- a/chamberconnectlibrary/watlowf4t.py
+++ b/chamberconnectlibrary/watlowf4t.py
@@ -77,7 +77,7 @@ class WatlowF4T(ControllerInterface):
         self.__update_loop_map()
         self.watlow_val_dict = {
             1:'2', 2:'3', 3:'50Hz', 4:'60Hz', 9:'ambientError',
-            10:'auto', 11:'b', 13: 'both', 15:u'C', 17:'closeOnAlarm',
+            10:'auto', 11:'b', 13: 'both', 15:'C', 17:'closeOnAlarm',
             22:'current', 23:'d', 24:'deviationAlarm', 26:'e', 27:'end', 28:'error',
             30:'F', 31:'factory', 32:'fail', 34:'fixedTimeBase', 37:'high', 39:'hours',
             40:'hundredths', 44:'inputDryContact', 46:'j', 47:'hold', 48:'k', 49:'latching',
@@ -132,7 +132,7 @@ class WatlowF4T(ControllerInterface):
         try:
             return self.iwatlow_val_dict[key]
         except Exception:
-            self.iwatlow_val_dict = {v: k for k, v in self.watlow_val_dict.items()}
+            self.iwatlow_val_dict = {v: k for k, v in list(self.watlow_val_dict.items())}
             return self.iwatlow_val_dict[key]
 
     def __update_loop_map(self):
@@ -853,7 +853,7 @@ class WatlowF4T(ControllerInterface):
         try:
             self.client.write_holding(18888, N) #set active profile
             self.client.write_holding(18890, self.inv_watlow_val_dict('delete')) #delete profile
-        except ModbusError, exp:
+        except ModbusError as exp:
             exp.message = 'Cannot delete program. (original message: %s)' % exp.message
             raise # something else went wrong pass the exception on up.
 
@@ -1000,11 +1000,11 @@ class WatlowF4T(ControllerInterface):
             tlist = ['absoluteTemperature', 'relativeTemperature', 'notsourced']
             if self.watlow_val_dict[profpv] in tlist:
                 tval = self.client.read_holding(14080 if self.interface == "RTU" else 6730, 1)[0]
-                return u'\xb0%s' % self.watlow_val_dict[tval]
+                return '\xb0%s' % self.watlow_val_dict[tval]
             else:
-                return u'%s' % self.watlow_val_dict[profpv]
+                return '%s' % self.watlow_val_dict[profpv]
         except LookupError:
-            return u'ERROR'
+            return 'ERROR'
 
     def __get_prgm_empty(self):
         '''

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 setup(
     name='chamberconnectlibrary',
-    version='2.2.5',
+    version='2.3.0',
     description='A library for interfacing with Espec North America chambers',
     long_description=readme(),
     url='https://github.com/EspecNorthAmerica/ChamberConnectLibrary',


### PR DESCRIPTION
Hi, 

`python2` is approaching end of life and most of our setup is already on `python3`.
This PR add `python3` support and was tested on a `WatlowF4T` using TCP.

test:
```sh
$ cd ChamberConnectLibrary
$ virtualenv -p python3 venv3
$ venv3/bin/pip install .
$ source venv3/bin/activate
$ python3 bin/chamberconnectlibrary-test.py WatlowF4T TCP 192.168.100.59

[ ... ]

Testing Complete
```