### PR TITLE
Fix time remaining carry bug in Watlow F4 get_prgm_time implementation

### DIFF
--- a/chamberconnectlibrary/watlowf4.py
+++ b/chamberconnectlibrary/watlowf4.py
@@ -672,7 +672,7 @@ class WatlowF4(ControllerInterface):
                 stepi += 1
         rtime[1] += int(rtime[2]/60)
         rtime[2] = int(rtime[2]%60)
-        rtime[0] += int(rtime[2]/60)
+        rtime[0] += int(rtime[1]/60)
         rtime[1] = int(rtime[1]%60)
         return '%d:%02d:%02d' % tuple(rtime)
 


### PR DESCRIPTION
Hi, when using this library with a Watlow F4 chamber, I discovered that the profile time remaining calculation wasn't carrying over the minutes to hours properly. Here is a tiny PR that fixes that bug.